### PR TITLE
fix: use exact string matching in swap chain_id and coin_config validation

### DIFF
--- a/app/src/swap/swap_utils.c
+++ b/app/src/swap/swap_utils.c
@@ -38,7 +38,8 @@ int8_t find_chain_index_by_coin_config(const char *coin_config,
   }
 
   for (uint8_t i = 0; i < chains_len; i++) {
-    if (strncmp(coin_config, PIC(chains[i].coin_config), coin_config_len) ==
+    if (coin_config_len == strlen(PIC(chains[i].coin_config)) &&
+        strncmp(coin_config, PIC(chains[i].coin_config), coin_config_len) ==
         0) {
       return i;
     }
@@ -53,8 +54,7 @@ int8_t find_chain_index_by_chain_id(const char *chain_id) {
   }
 
   for (uint8_t i = 0; i < chains_len; i++) {
-    if (strncmp(chain_id, PIC(chains[i].chain_id),
-                strlen(PIC(chains[i].chain_id))) == 0) {
+    if (strcmp(chain_id, PIC(chains[i].chain_id)) == 0) {
       return i;
     }
   }


### PR DESCRIPTION
`find_chain_index_by_chain_id()` used `strncmp` with `strlen` of the stored chain_id, performing a prefix match instead of an exact comparison. Any chain_id starting with a known prefix (e.g. 'cosmoshub-4-evil' matching 'cosmoshub-4') would pass validation. Fixed by replacing with `strcmp` since both inputs are null-terminated.

`find_chain_index_by_coin_config()` used `strncmp` with the caller-provided length without checking it against the stored string length. A shorter input (e.g. 'cosmo') could match a longer stored value (e.g. 'cosmos').
Added length equality check before `strncmp` since coin_config comes with an explicit length byte and is not guaranteed to be null-terminated.

Both issues were reported and acknowledged through the Ledger Bug Bounty program.