### PR TITLE
feat(chain-config): add Gonka coin type 1200 with exclusive HRP resolution

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -65,7 +65,7 @@ CURVE_APP_LOAD_PARAMS = secp256k1
 # If your app needs it, you can specify multiple path by using:
 # `PATH_APP_LOAD_PARAMS = "44'/1'" "45'/1'"`
 
-APPPATH =  "44'/118'" "44'/60'"
+APPPATH =  "44'/118'" "44'/60'" "44'/1200'"
 $(info PATHS LIST = $(APPPATH))
 PATH_APP_LOAD_PARAMS = $(APPPATH)
 

--- a/app/Makefile.version
+++ b/app/Makefile.version
@@ -3,4 +3,4 @@ APPVERSION_M=2
 # This is the `spec_version` field of `Runtime`
 APPVERSION_N=39
 # This is the patch version of this release
-APPVERSION_P=1
+APPVERSION_P=2

--- a/app/src/apdu_handler.c
+++ b/app/src/apdu_handler.c
@@ -108,9 +108,7 @@ __Z_INLINE void extractHDPath(uint32_t rx, uint32_t offset) {
          sizeof(uint32_t) * HDPATH_LEN_DEFAULT);
 
   // Check values
-  if (hdPath[0] != HDPATH_0_DEFAULT ||
-      ((hdPath[1] != HDPATH_1_DEFAULT) &&
-       (hdPath[1] != HDPATH_ETH_1_DEFAULT)) ||
+  if (hdPath[0] != HDPATH_0_DEFAULT || !isSupportedCoinType(hdPath[1]) ||
       hdPath[3] != HDPATH_3_DEFAULT) {
     THROW(APDU_CODE_INVALID_HD_PATH_COIN_VALUE);
   }
@@ -139,7 +137,11 @@ static void extractHDPath_HRP(uint32_t rx, uint32_t offset) {
       ZEMU_LOGF(50, "Chain config not supported for: %s\n", bech32_hrp)
       THROW(APDU_CODE_CHAIN_CONFIG_NOT_SUPPORTED);
     }
-  } else if (hdPath[1] == HDPATH_ETH_1_DEFAULT) {
+  } else if (hdPath[1] != HDPATH_1_DEFAULT) {
+    // Only the generic Cosmos path (118) has a meaningful default HRP.
+    // Falling through on any other coin type would derive a key on that
+    // chain's path while defaulting the review screen to a cosmos1...
+    // address -- a silent mismatch on the one screen the user checks.
     THROW(APDU_CODE_INVALID_HD_PATH_COIN_VALUE);
   } else {
     // No HRP was provided on the default Cosmos path. Restore the default

--- a/app/src/chain_config.c
+++ b/app/src/chain_config.c
@@ -24,7 +24,8 @@ typedef struct {
 } chain_config_t;
 
 // To enable custom config for a new chain, just add a new entry in this array
-// with path, hrp and encoding
+// with path, hrp and encoding. Declaring a coin type here also makes it
+// derivable -- see isSupportedCoinType.
 static const chain_config_t chainConfig[] = {
     {118, "cosmos", BECH32_COSMOS},   {60, "inj", BECH32_ETH},
     {60, "evmos", BECH32_ETH},        {60, "xpla", BECH32_ETH},
@@ -33,10 +34,24 @@ static const chain_config_t chainConfig[] = {
     {118, "osmo", BECH32_COSMOS},     {118, "dydx", BECH32_COSMOS},
     {118, "mantra", BECH32_COSMOS},   {118, "xion", BECH32_COSMOS},
     {118, "celestia", BECH32_COSMOS}, {118, "core", BECH32_COSMOS},
-    {118, "neutron", BECH32_COSMOS}};
+    {118, "neutron", BECH32_COSMOS},  {1200, "gonka", BECH32_COSMOS}};
 
 static const uint32_t chainConfigLen =
     sizeof(chainConfig) / sizeof(chainConfig[0]);
+
+bool isSupportedCoinType(uint32_t path) {
+  if (path == HDPATH_1_DEFAULT || path == HDPATH_ETH_1_DEFAULT) {
+    return true;
+  }
+
+  for (uint32_t i = 0; i < chainConfigLen; i++) {
+    if (path == (0x80000000u | chainConfig[i].path)) {
+      return true;
+    }
+  }
+
+  return false;
+}
 
 address_encoding_e checkChainConfig(uint32_t path, const char *hrp,
                                     uint8_t hrpLen) {

--- a/app/src/chain_config.h
+++ b/app/src/chain_config.h
@@ -26,6 +26,10 @@ extern "C" {
 address_encoding_e checkChainConfig(uint32_t path, const char *hrp,
                                     uint8_t hrpLen);
 
+// `path` is the hardened coin type element of the derivation path (hdPath[1]),
+// as taken by checkChainConfig.
+bool isSupportedCoinType(uint32_t path);
+
 #ifdef __cplusplus
 }
 #endif

--- a/app/src/swap/handle_check_address.c
+++ b/app/src/swap/handle_check_address.c
@@ -77,6 +77,15 @@ void handle_check_address(check_address_parameters_t *params) {
     return;
   }
 
+  // Being able to derive the address is not enough: the swap can only be
+  // carried through on a chain this app also knows how to price and to verify
+  // at signing time (chains[] in swap_utils.c). Claiming the address here for
+  // any other chain lets Exchange commit the user to a swap that can only be
+  // refused later, at the signing step.
+  if (find_chain_index_by_coin_config(hrp, hrp_length) < 0) {
+    return;
+  }
+
   char address_computed[100] = {0};
   uint16_t reply_len = 0;
   zxerr_t err = crypto_swap_fillAddress(bip32_path, bip32_path_length, hrp,

--- a/docs/APDUSPEC.md
+++ b/docs/APDUSPEC.md
@@ -85,12 +85,27 @@ The general structure of commands and responses is as follows:
 | HRP_LEN    | byte(1)        | Bech32 HRP Length              | 1<=HRP_LEN<=83 |
 | HRP        | byte (HRP_LEN) | Bech32 HRP                     |                |
 | Path[0]    | byte (4)       | Derivation Path Data           | 44             |
-| Path[1]    | byte (4)       | Derivation Path Data           | 118 / 60       |
+| Path[1]    | byte (4)       | Derivation Path Data           | 118 / 60 / declared |
 | Path[2]    | byte (4)       | Derivation Path Data           | ?              |
 | Path[3]    | byte (4)       | Derivation Path Data           | ?              |
 | Path[4]    | byte (4)       | Derivation Path Data           | ?              |
 
 First three items in the derivation path will be hardened automatically hardened
+
+##### Accepted coin types and HRPs
+
+`Path[1]` accepts 118 (the generic Cosmos path), 60 (the Ethereum-style family) and any coin type
+declared in the app's chain configuration — currently 1200 (Gonka). Any other value is rejected with
+`APDU_CODE_INVALID_HD_PATH_COIN_VALUE`.
+
+The HRP is then resolved against that same configuration:
+
+- 118 accepts any HRP, except one declared for a coin type of its own — a chain that owns a coin
+  type is reachable only through it, so it has a single account rather than one per path.
+- Every other coin type — 60 and any coin type the chain configuration declares — accepts only the
+  HRP declared for it.
+
+Any other pair is rejected with `APDU_CODE_CHAIN_CONFIG_NOT_SUPPORTED`.
 
 #### Response
 
@@ -116,7 +131,10 @@ First three items in the derivation path will be hardened automatically hardened
 | L     | byte (1) | Bytes in payload       | (depends) |
 
 The first packet/chunk includes only the derivation path and HRP.
-At the moment, seding HRP is optional but it will be mandatory in a future version.
+Sending the HRP is optional on the generic Cosmos path (118) only, where it defaults to `cosmos`; it
+will be mandatory in a future version. On every other coin type — 60 and any coin type the chain
+configuration declares — the HRP names the chain being signed for, so omitting it is rejected with
+`APDU_CODE_INVALID_HD_PATH_COIN_VALUE`.
 
 All other packets/chunks should contain message to sign
 
@@ -125,7 +143,7 @@ All other packets/chunks should contain message to sign
 | Field      | Type     | Content                | Expected  |
 | ---------- | -------- | ---------------------- | --------- |
 | Path[0]    | byte (4)       | Derivation Path Data           | 44             |
-| Path[1]    | byte (4)       | Derivation Path Data           | 118 / 60       |
+| Path[1]    | byte (4)       | Derivation Path Data           | 118 / 60 / declared |
 | Path[2]    | byte (4)       | Derivation Path Data           | ?              |
 | Path[3]    | byte (4)       | Derivation Path Data           | ?              |
 | Path[4]    | byte (4)       | Derivation Path Data           | ?              |

--- a/tests/chain_config.cpp
+++ b/tests/chain_config.cpp
@@ -216,3 +216,76 @@ TEST(ChainConfig, ValidPrintableLowercaseHrpsAreUnaffected) {
         << hrp;
   }
 }
+
+// ---------------------------------------------------------------------------
+// Coin types outside the two built-in defaults, of which Gonka (1200') is the
+// first. isSupportedCoinType() lets the APDU layer accept the path;
+// checkChainConfig() then decides the pair -- unchanged above -- exactly as
+// it already does for 60'.
+// ---------------------------------------------------------------------------
+
+TEST(ChainConfig, DeclaredCoinTypeResolvesOnItsOwnHrp) {
+  EXPECT_EQ(check(1200, "gonka"), BECH32_COSMOS);
+}
+
+TEST(ChainConfig, DeclaredCoinTypeIsRefusedUnderAnotherHrp) {
+  EXPECT_EQ(check(1200, "cosmos"), UNSUPPORTED);
+  EXPECT_EQ(check(1200, "inj"), UNSUPPORTED);
+  EXPECT_EQ(check(1200, "osmo"), UNSUPPORTED);
+}
+
+// The generic fallback is scoped to 118' and does not extend to a declared
+// coin type.
+TEST(ChainConfig, UnknownHrpDoesNotFallBackOnADeclaredCoinType) {
+  for (const char *hrp : {"akash", "juno", "gonk", "gonkavaloper"}) {
+    EXPECT_EQ(check(1200, hrp), UNSUPPORTED) << hrp << " was accepted on 1200'";
+  }
+}
+
+// Same statement as KnownHrpOnTheGenericCosmosPathIsRefused, for the entry
+// this change adds: the HRP-first lookup above refuses "gonka" on 118' with
+// no dedicated exclusivity check needed.
+TEST(ChainConfig, DeclaredHrpIsRefusedOnTheGenericCosmosPath) {
+  EXPECT_EQ(check(118, "gonka"), UNSUPPORTED);
+}
+
+TEST(ChainConfig, BuiltInCoinTypesAreSupported) {
+  EXPECT_TRUE(isSupportedCoinType(0x80000000u | 118u));
+  EXPECT_TRUE(isSupportedCoinType(0x80000000u | 60u));
+}
+
+TEST(ChainConfig, DeclaredCoinTypeIsSupported) {
+  EXPECT_TRUE(isSupportedCoinType(0x80000000u | 1200u));
+}
+
+// Accepting a path the table cannot resolve would let the device derive a key
+// it can never encode into an address.
+TEST(ChainConfig, UndeclaredCoinTypeIsNotSupported) {
+  for (const uint32_t coinType : {0u, 1u, 119u, 529u, 1199u, 1201u}) {
+    EXPECT_FALSE(isSupportedCoinType(0x80000000u | coinType)) << coinType;
+  }
+}
+
+// hdPath[1] always arrives hardened; an unhardened value must not slip through.
+TEST(ChainConfig, NonHardenedCoinTypeIsNotSupported) {
+  EXPECT_FALSE(isSupportedCoinType(118));
+  EXPECT_FALSE(isSupportedCoinType(60));
+  EXPECT_FALSE(isSupportedCoinType(1200));
+}
+
+// A pair the table resolves must sit on a coin type the APDU layer accepts.
+TEST(ChainConfig, EveryResolvablePairSitsOnASupportedCoinType) {
+  const struct {
+    uint32_t coinType;
+    const char *hrp;
+  } pairs[] = {
+      {118, "cosmos"}, {118, "osmo"},     {118, "dydx"}, {118, "mantra"},
+      {118, "xion"},   {118, "celestia"}, {118, "core"}, {118, "neutron"},
+      {60, "inj"},      {60, "evmos"},     {60, "xpla"},  {60, "dym"},
+      {60, "zeta"},     {60, "bera"},      {60, "human"}, {1200, "gonka"}};
+
+  for (const auto &pair : pairs) {
+    EXPECT_NE(check(pair.coinType, pair.hrp), UNSUPPORTED) << pair.hrp;
+    EXPECT_TRUE(isSupportedCoinType(0x80000000u | pair.coinType)) << pair.hrp;
+  }
+}

--- a/tests_zemu/tests/standard.test.ts
+++ b/tests_zemu/tests/standard.test.ts
@@ -84,6 +84,80 @@ describe('Standard', function () {
     }
   })
 
+  test.concurrent.each(DEVICE_MODELS)('get address on a declared coin type (Gonka)', async function (m) {
+    const sim = new Zemu(m.path)
+    try {
+      await sim.start({ ...defaultOptions, model: m.name })
+      const app = new CosmosApp(sim.getTransport())
+
+      // Derivation path. First 3 items are automatically hardened!
+      const path = "m/44'/1200'/0'/0/0"
+      const resp = await app.getAddressAndPubKey(path, 'gonka')
+
+      console.log(resp)
+
+      expect(resp).toHaveProperty('bech32_address')
+      expect(resp).toHaveProperty('compressed_pk')
+
+      expect(resp.bech32_address).toEqual('gonka1j0pzd70wr9muhpdp5ahladpzznq95lr3xwkrsg')
+      expect(resp.compressed_pk.length).toEqual(33)
+    } finally {
+      await sim.close()
+    }
+  })
+
+  test.concurrent.each(DEVICE_MODELS)('a declared coin type refuses a prefix declared for another one', async function (m) {
+    const sim = new Zemu(m.path)
+    try {
+      await sim.start({ ...defaultOptions, model: m.name })
+      const app = new CosmosApp(sim.getTransport())
+
+      const path = "m/44'/1200'/0'/0/0"
+      const errorRespPk = app.getAddressAndPubKey(path, 'cosmos')
+      await expect(errorRespPk).rejects.toMatchObject({
+        returnCode: 0x698C,
+        errorMessage: 'Chain config not supported'
+      })
+    } finally {
+      await sim.close()
+    }
+  })
+
+  test.concurrent.each(DEVICE_MODELS)('the generic Cosmos path refuses a prefix owned by its own coin type', async function (m) {
+    const sim = new Zemu(m.path)
+    try {
+      await sim.start({ ...defaultOptions, model: m.name })
+      const app = new CosmosApp(sim.getTransport())
+
+      // Gonka owns 1200', so it has one account -- not a second one reachable
+      // through the generic 118' path under the same gonka1... shape.
+      const path = "m/44'/118'/0'/0/0"
+      const errorRespPk = app.getAddressAndPubKey(path, 'gonka')
+      await expect(errorRespPk).rejects.toMatchObject({
+        returnCode: 0x698C,
+        errorMessage: 'Chain config not supported'
+      })
+    } finally {
+      await sim.close()
+    }
+  })
+
+  test.concurrent.each(DEVICE_MODELS)('a coin type that is neither built-in nor declared is refused', async function (m) {
+    const sim = new Zemu(m.path)
+    try {
+      await sim.start({ ...defaultOptions, model: m.name })
+      const app = new CosmosApp(sim.getTransport())
+
+      const path = "m/44'/529'/0'/0/0"
+      const errorRespPk = app.getAddressAndPubKey(path, 'secret')
+      await expect(errorRespPk).rejects.toMatchObject({
+        returnCode: 0x698B,
+      })
+    } finally {
+      await sim.close()
+    }
+  })
+
   test.concurrent.each(DEVICE_MODELS)('show address', async function (m) {
     const sim = new Zemu(m.path)
     try {


### PR DESCRIPTION
## Context
Gonka (GNK) registers and derives on its own SLIP-0044 coin type, 1200 — not one of the two coin types (118, 60) this app currently accepts. LIVE-36205.

## Changes
- `chain_config.c`/`.h`: derive the accepted coin types from the chain-configuration table (`isSupportedCoinType`) instead of the two hard-coded constants; declare `{1200, "gonka", BECH32_COSMOS}`.
- A chain that owns a coin type of its own is now reachable only through it: the generic 118' fallback no longer mints a prefix declared for such a coin type.
- `apdu_handler.c`: the no-HRP guard on signing, previously specific to coin type 60, is generalised to every coin type other than 118 — needed so that signing on 1200 without an HRP fails loudly instead of silently defaulting to a `cosmos1...` review screen.
- `app/Makefile`: declare `44'/1200'` in `APPPATH` (`PATH_APP_LOAD_PARAMS`) — the OS-enforced allowed-paths gate, independent of the checks above.
- `app/src/swap/handle_check_address.c`: swap `check_address` now answers only for chains the app can also price and verify at signing time.
- `CMakeLists.txt`: link `chain_config.c` into the unit-test binary.
- New `tests/chain_config.cpp` unit suite; new Zemu cases in `standard.test.ts`.
- `app/Makefile.version`: patch bump.

## Tests
- Unit tests: full suite green locally (154/154, including the added ChainConfig cases).
- Zemu cases added; not executed as part of this change.

## Risks
- Behavioural change on coin type 118: a prefix declared for another coin type (currently only `gonka`) is no longer accepted there. Every other pair (118 with any other prefix, 60, and any previously declared coin type) is unaffected.

## Related
- LIVE-36205